### PR TITLE
Add overload for load_data to use raw C strings as source

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -177,6 +177,7 @@ public:
 
             _hppOutput.append(String("void load_file(const std::string& file, ") + elementTypeCppName + "& " + elementCppName + ");");
             _hppOutput.append(String("void load_data(const std::string& data, ") + elementTypeCppName + "& " + elementCppName + ");");
+            _hppOutput.append(String("void load_data(const char* data, ") + elementTypeCppName + "& " + elementCppName + ");");
             _hppOutput.append("");
         }
 
@@ -221,12 +222,18 @@ public:
             String elementTypeCppName = toCppTypeIdentifier2(i->typeName);
             String elementCppName = toCppFieldIdentifier(i->name);
 
-            _cppOutputFinal.append(String("void load_data(const std::string& data, ") + elementTypeCppName + "& output)");
+            _cppOutputFinal.append(String("void load_data(const char* data, ") + elementTypeCppName + "& output)");
             _cppOutputFinal.append("{");
             _cppOutputFinal.append(String("    ") + rootTypeCppName + " rootElement;");
             _cppOutputFinal.append(String("    xsdcpp::ElementContext elementContext(&_") + rootTypeCppName + "_Info, &rootElement);");
-            _cppOutputFinal.append("    xsdcpp::parse(data.c_str(), _namespaces, elementContext);");
+            _cppOutputFinal.append("    xsdcpp::parse(data, _namespaces, elementContext);");
             _cppOutputFinal.append(String("    output = std::move(rootElement.") + elementCppName + ");");
+            _cppOutputFinal.append("}");
+            _cppOutputFinal.append("");
+
+            _cppOutputFinal.append(String("void load_data(const std::string& data, ") + elementTypeCppName + "& output)");
+            _cppOutputFinal.append("{");
+            _cppOutputFinal.append("    load_data(data.c_str(), output);");
             _cppOutputFinal.append("}");
             _cppOutputFinal.append("");
 


### PR DESCRIPTION
Background: I am using this library on an ESP32 where we store XML data in external SPI RAM. Currently, xsdcpp only allows loading data from a `std::string` or a file (which loads into `std::string` anyway), which would require us to use main memory for the source data, which is often unfeasible due to space constraints.

This PR adds a simple overload to allow using a `const char*` directly, bypassing the `std::string` interface requirement. It passes all provided tests.